### PR TITLE
fixed issue that allowed authorization with invalid username for SQL db

### DIFF
--- a/server/models/UserSqlite.js
+++ b/server/models/UserSqlite.js
@@ -3,7 +3,7 @@ let db = require('./dbSqlite')
 async function findByUsername(username) { 
   console.log('Looking up username ', username)
   return new Promise((resolve, reject) => {
-    db.get('select id as _id, username, password, isAgent from user', (err, row) => {
+    db.get('select id as _id, username, password, isAgent from user where username="'+username+'"', (err, row) => {
       if (err) {
         reject(err)
       }


### PR DESCRIPTION
When the code was modified to integrate SQL db, the function findByUsername in UserSqlite was left incomplete.
It created the issue that only the password was required to match while the username was irrelevant. 
It was fixed by changing DB query to serch by username to return the same data that the Mongoose implementation returns.